### PR TITLE
[REFACTOR] sns 로그인 email 추가 && successHandler 로직 수정 #120

### DIFF
--- a/src/main/java/umc/tickettaka/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/umc/tickettaka/config/security/jwt/JwtTokenProvider.java
@@ -35,7 +35,7 @@ public class JwtTokenProvider {
     }
 
     // Member 정보를 가지고 AccessToken, RefreshToken을 생성하는 메서드
-    public JwtToken generateToken(Authentication authentication, String username, Boolean rememberMe) {
+    public JwtToken generateToken(Authentication authentication, String username, Boolean keepStatus) {
         // 권한 가져오기
         String authorities = authentication.getAuthorities().stream()
             .map(GrantedAuthority::getAuthority)
@@ -45,7 +45,7 @@ public class JwtTokenProvider {
 
         // Access Token 생성
         Date accessTokenExpiresIn = null;
-        if (rememberMe) {
+        if (keepStatus) {
             accessTokenExpiresIn = new Date(now + 864000 * 7); // 만약 login 유지에 체크한 경우 일주일
         }
         else {

--- a/src/main/java/umc/tickettaka/converter/MemberConverter.java
+++ b/src/main/java/umc/tickettaka/converter/MemberConverter.java
@@ -68,7 +68,7 @@ public class MemberConverter {
         String username = signUpDto.getUsername();
         String imageUrl = signUpDto.getImageUrl();
         String providerType = signUpDto.getProviderType();
-        String providerId = signUpDto.getProviderId();
+        String email = signUpDto.getEmail();
         String deviceToken = signUpDto.getDeviceToken();
 
         ProviderType providerTypeEnum = null;
@@ -82,7 +82,7 @@ public class MemberConverter {
             .password(encodedPassword)
             .imageUrl(imageUrl)
             .providerType(providerTypeEnum)
-            .providerId(providerId)
+            .email(email)
             .deviceToken(deviceToken)
             .roles(Collections.singletonList("ROLE_USER"))
             .build();

--- a/src/main/java/umc/tickettaka/domain/Member.java
+++ b/src/main/java/umc/tickettaka/domain/Member.java
@@ -54,7 +54,7 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ProviderType providerType;
 
-    private String providerId;
+    private String email;
 
     private String deviceToken; // 기기 연동을 위한 토큰
 

--- a/src/main/java/umc/tickettaka/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/umc/tickettaka/oauth/CustomOAuth2UserService.java
@@ -53,21 +53,20 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         if (registrationId.equals("kakao")) {
             targetAttributes.put("id", "id");  // defaultOAuth2User 생성을 위한 targetAttributes에는 userNameAttributeName이 포함되어있어야 한다. ( 코드가 그렇게 되어있음)
-            targetAttributes.put("providerId", String.valueOf((Long) oAuth2User.getAttribute("id")));
 
             Map<String, Object> kakao_account = (Map<String, Object>) attributes.get("kakao_account");
             Map<String, Object> profile = (Map<String, Object>) kakao_account.get("profile");
             String nickname = (String) profile.get("nickname");
             targetAttributes.put("nickname", nickname);
+            String email = (String) kakao_account.get("email");
+            targetAttributes.put("email", email);
         }
         else if (registrationId.equals("naver")) {
             targetAttributes.put("response", "response"); //userNameAttributeName
             Map<String, Object> response = (Map<String, Object>) attributes.get("response");
-            targetAttributes.put("providerId", response.get("id"));
             targetAttributes.put("email", response.get("email"));
         }
         else if (registrationId.equals("google")) {
-            targetAttributes.put("providerId", oAuth2User.getAttribute("sub"));
             targetAttributes.put("sub", "sub"); //userNameAttributeName
             targetAttributes.put("email", oAuth2User.getAttribute("email"));
 

--- a/src/main/java/umc/tickettaka/repository/MemberRepository.java
+++ b/src/main/java/umc/tickettaka/repository/MemberRepository.java
@@ -4,14 +4,12 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import umc.tickettaka.domain.Member;
+import umc.tickettaka.domain.enums.ProviderType;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUsername(String userName);
-
-    Optional<Member> findByProviderId(String providerId);
-
 
     @EntityGraph(attributePaths = {"ticketList"})
     Optional<Member> findMemberWithTicketsById(Long memberId);
@@ -19,4 +17,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @EntityGraph(attributePaths = {"memberTeamList", "memberTeamList.team"})
     Optional<Member> findMemberWitMemberTeamById(Long memberId);
 
+    Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByEmailAndProviderType(String email, ProviderType providerType);
 }

--- a/src/main/java/umc/tickettaka/service/MemberQueryService.java
+++ b/src/main/java/umc/tickettaka/service/MemberQueryService.java
@@ -10,5 +10,6 @@ public interface MemberQueryService {
 
     Member findMemberWithTicketsAndMemberTeamsByMemberId(Long memberId);
 
-    Optional<Member> findByProviderId(String providerId);
+    Optional<Member> findByEmail(String email);
+    Optional<Member> findByEmailAndProvider(String email, String provider);
 }

--- a/src/main/java/umc/tickettaka/service/impl/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/tickettaka/service/impl/MemberCommandServiceImpl.java
@@ -70,24 +70,32 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     @Override
     @Transactional
     public Member save(SignRequestDto.SignUpDto signUpDto) {
-        // null check front에서 1차적으로 해야하지만, backend에서 한번 더 체크
-        if(signUpDto.getUsername() == null || signUpDto.getPassword() == null || signUpDto.getPassword2() == null)
-            throw new GeneralException(ErrorStatus.BAD_REQUEST, "입력 값 중에 null이 있습니다.");
+        Member member = null;
+        // sns 로그인이 아닌 일반 로그인인 경우
+        if (signUpDto.getProviderType() == null) {
+            // null check front에서 1차적으로 해야하지만, backend에서 한번 더 체크
+            if(signUpDto.getUsername() == null || signUpDto.getPassword() == null || signUpDto.getPassword2() == null)
+                throw new GeneralException(ErrorStatus.BAD_REQUEST, "입력 값 중에 null이 있습니다.");
 
-        // duplicate check
-        String username = signUpDto.getUsername();
-        checkDuplicateMember(username);
+            // duplicate check
+            String username = signUpDto.getUsername();
+            checkDuplicateMember(username);
 
-        // check password == password2
-        if(!Objects.equals(signUpDto.getPassword(), signUpDto.getPassword2()))
-            throw new GeneralException(ErrorStatus.MEMBER_WRONG_INFORMATION, "password와 passsword 확인이 다릅니다.");
+            // check password == password2
+            if(!Objects.equals(signUpDto.getPassword(), signUpDto.getPassword2()))
+                throw new GeneralException(ErrorStatus.MEMBER_WRONG_INFORMATION, "password와 passsword 확인이 다릅니다.");
 
-        // password encoding
-        String password = signUpDto.getPassword();
-        String encodedPassword = passwordEncoder.encode(password);
+            // password encoding
+            String password = signUpDto.getPassword();
+            String encodedPassword = passwordEncoder.encode(password);
 
-        // dto to member
-        Member member = MemberConverter.toMember(signUpDto, encodedPassword);
+            // dto to member
+            member = MemberConverter.toMember(signUpDto, encodedPassword);
+        }
+        // sns 로그인인 경우
+        else {
+            member = MemberConverter.toMember(signUpDto, null);
+        }
         return memberRepository.save(member);
     }
 

--- a/src/main/java/umc/tickettaka/service/impl/MemberQueryServiceImpl.java
+++ b/src/main/java/umc/tickettaka/service/impl/MemberQueryServiceImpl.java
@@ -4,16 +4,21 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.tickettaka.converter.MemberConverter;
 import umc.tickettaka.domain.Member;
+import umc.tickettaka.domain.enums.ProviderType;
 import umc.tickettaka.domain.ticket.Ticket;
 import umc.tickettaka.payload.exception.GeneralException;
 import umc.tickettaka.payload.status.ErrorStatus;
 import umc.tickettaka.repository.MemberRepository;
 import umc.tickettaka.repository.TicketRepository;
 import umc.tickettaka.service.MemberQueryService;
+import umc.tickettaka.web.dto.response.MemberResponseDto;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -48,7 +53,14 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     }
 
     @Override
-    public Optional<Member> findByProviderId(String providerId) {
-        return memberRepository.findByProviderId(providerId);
+    public Optional<Member> findByEmail(String email) {
+        return memberRepository.findByEmail(email);
     }
+
+    @Override
+    public Optional<Member> findByEmailAndProvider(String email, String provider) {
+        return memberRepository.findByEmailAndProviderType(email, ProviderType.valueOf(provider));
+    }
+
+
 }

--- a/src/main/java/umc/tickettaka/web/dto/request/SignRequestDto.java
+++ b/src/main/java/umc/tickettaka/web/dto/request/SignRequestDto.java
@@ -1,14 +1,16 @@
 package umc.tickettaka.web.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Data;
-import lombok.Getter;
+import lombok.*;
 
 @Data
 @Schema(description = "jwt request dto")
 public class SignRequestDto {
 
+    @Builder
     @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     @Schema(name = "sign in dto")
     public static class SignInDto {
 
@@ -20,7 +22,10 @@ public class SignRequestDto {
 
     }
 
+    @Builder
     @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     @Schema(name = "sign up dto")
     public static class SignUpDto {
 
@@ -38,7 +43,7 @@ public class SignRequestDto {
 
         private String providerType;
 
-        private String providerId;
+        private String email;
 
     }
 }

--- a/src/main/resources/application-secret.yml
+++ b/src/main/resources/application-secret.yml
@@ -38,6 +38,7 @@ spring:
             client-name: kakao
             scope:
               - profile_nickname
+              - account_email
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_SECRET_ID}


### PR DESCRIPTION
1. member email 추가
2. email과 providerType(ex) kakao, naver) 모두를 사용해 유저 찾기
3. 만약 있는 경우 sns 로그인 후 DB에 저장되어있다는 것이므로 이를 바탕으로 SuccessHandler분기 처리 로직 작성